### PR TITLE
【Fixed】`rails g` コマンドでassetsファイルhelperファイルが自動生成されないよう制限

### DIFF
--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -20,7 +20,7 @@ class PicturesController < ApplicationController
     @picture = current_user.pictures.build(picture_params)
     render :new and return if params[:back]
     if @picture.save
-      PostedMailer.posted_mail(@picture).deliver
+      # PostedMailer.posted_mail(@picture).deliver
       redirect_to pictures_path, notice: "Posting completed."
     else
       render :new

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,8 +2,6 @@ require_relative 'boot'
 
 require 'rails/all'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module Prestagram
@@ -12,16 +10,11 @@ module Prestagram
     config.active_record.default_timezone = :local
 
     config.i18n.default_locale = :ja
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
     config.generators do |g|
       g.assets false
       g.helper false
     end
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
   end
 end


### PR DESCRIPTION
#1 

```
config.generators do |g|
      g.assets false
      g.helper false
    end
```
上記のコードをconfig / application.rb に追記